### PR TITLE
Fix: Connection refused by API server if container is on 2 networks

### DIFF
--- a/start-k3s.sh
+++ b/start-k3s.sh
@@ -37,7 +37,7 @@ K3S_ARGS=( \
     --no-deploy=traefik \
     --docker \
     --https-listen-port=8443 \
-    --bind-address=${K3S_NAME} \
+    --bind-address=0.0.0.0 \
     --node-name=${K3S_NAME} \
     --tls-san=${K3S_NAME} \
 )
@@ -49,7 +49,7 @@ function runServer {
 function getKubeconfig {
     local cfg=$(cat /etc/rancher/k3s/k3s.yaml)
     if [[ $cfg =~ password ]]; then
-        echo "${cfg}"
+        echo "${cfg}" | sed 's/\/\/0.0.0.0:/\/\/'"${K3S_NAME}"':/'
     fi
 }
 


### PR DESCRIPTION
Because the k3s bind address was set to the container's hostname, if the
container has more than one interface (i.e. connected to more than one
docker network), the DNS lookup for the hostname could return any of the
IPs.
Fix is to listen on all addresses (0.0.0.0), but then the generated
kubeconfig is invalid, so replace 0.0.0.0 with the container hostname.