### PR TITLE
Add get-kubeconfig script that will wait for, then cat kubeconfig.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ ENV K3S_VERSION=v0.5.0
 EXPOSE 8443
 
 ADD https://github.com/rancher/k3s/releases/download/${K3S_VERSION}/k3s /usr/local/bin/k3s
-COPY kubectl start-k3s.sh /usr/local/bin/
+COPY kubectl start-k3s.sh get-kubeconfig.sh /usr/local/bin/
 
 # Note: the k3s kubectl command unpacks the k3s binaries as a side effect
 RUN  apk --no-cache add bash && \
     chmod a+x \
         /usr/local/bin/k3s \
         /usr/local/bin/start-k3s.sh \
+        /usr/local/bin/get-kubeconfig.sh \
         /usr/local/bin/kubectl \
         && \
     k3s kubectl --help > /dev/null

--- a/get-kubeconfig.sh
+++ b/get-kubeconfig.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+while [ ! -f /kubeconfig ]; do
+    sleep 1
+done
+
+if [ "$1" = "-json" ]; then
+    cfg=$(kubectl config view -o json --merge=true --flatten=true)
+else
+    cfg=$(kubectl config view -o yaml --merge=true --flatten=true)
+fi
+
+if [ -z "$2" ]; then
+    hostname="localhost"
+else 
+    hostname="$2"
+fi
+
+echo "$cfg" | sed -e "s/0\.0\.0\.0/$hostname/g"

--- a/start-k3s.sh
+++ b/start-k3s.sh
@@ -60,7 +60,8 @@ function waitForKubeconfig {
         cfg=$(getKubeconfig)
     done
 
-    echo "${cfg}" > /kubeconfig
+    echo "${cfg}" > /tmp/kubeconfig
+    mv /tmp/kubeconfig /kubeconfig
 }
 
 


### PR DESCRIPTION
Useful with docker exec to get the fully formed kubeconfig.  To use do docker exec -i -t <container> get-kubeconfig <-json | -yaml> [hostname].  Hostname defaults to localhost if omitted.