### PR TITLE
Bump k3s to 1.17.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:18.09.9-dind
 
-ENV K3S_VERSION=v1.0.0
+ENV K3S_VERSION="v1.17.0%2Bk3s.1"
 EXPOSE 8443
 
 ADD https://github.com/rancher/k3s/releases/download/${K3S_VERSION}/k3s /usr/local/bin/k3s


### PR DESCRIPTION
To test helm stuff locally we can avoid tiller by allowing Helm to be v3

Helm V3 is included in 1.17.0+ described [here](https://rancher.com/docs/k3s/latest/en/advanced/)